### PR TITLE
In-String Comments

### DIFF
--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -171,6 +171,7 @@ Raw Input | Output Character     | Output Code
 `\n`      | LINE FEED (LF)       | U+000A
 `\r`      | CARRIAGE RETURN (CR) | U+000D
 `\'`      | APOSTROPHE           | U+0027
+`\%`      | PERCENT SIGN         | U+0025
 `\\`      | REVERSE SOLIDUS      | U+005C
 `\u{24}`  | DOLLAR SIGN          | U+0024
 
@@ -186,6 +187,12 @@ and `\\` prints a literal backslash character without escaping the following one
 
 (Note that the code `\nighttime` would be cooked as a line feed followed by “ighttime”,
 since `\n` is the line feed character.)
+
+The code `\%` prints a literal percent sign without initiating an [in-string comment](#in-string-comments).
+```
+'The 10\% discount was not enough.';
+```
+> 'The 10% discount was not enough.'
 
 The code `\u{‹cp›}` escapes unicode characters, where ‹cp› is the code point of the character.
 For example, `\u{24}` escapes the dollar sign symbol, since its code point is **U+0024**.
@@ -216,36 +223,33 @@ Other than for the special cases listed above, a backslash has no effect.
 >
 > 'Any non-special character may be escaped.'
 
-**There’s one exception to this rule:** The code `\%` does not escape a percent sign —
-it initiates a comment.
-
 #### In-String Comments
 String literals may contain Solid comments.
-Line comments begin with `\%` and continue until (but not including) the next line break, and
-multiline comments begin with `\%%` and continue until (and including) the next `%%`.
+Line comments begin with `%` (**U+0025 PERCENT SIGN**) and continue until (but not including) the next line break, and
+multiline comments begin with `%%` and continue until (and including) the next `%%`.
 Both kinds of comments will continue until their end delimiter unless the end of the string is reached first.
 The commented content is removed from the string’s cooked value.
 
 -
 	```
-	'The five boxing wizards \% jump quickly.';
+	'The five boxing wizards % jump quickly.';
 	```
 	> 'The five boxing wizards '
 -
 	```
-	'The five \% boxing wizards
+	'The five % boxing wizards
 	jump quickly.';
 	```
 	> 'The five \
 	> jump quickly.'
 -
 	```
-	'The five \%% boxing wizards %% jump quickly.';
+	'The five %% boxing wizards %% jump quickly.';
 	```
 	> 'The five  jump quickly.'
 -
 	```
-	'The five \%% boxing
+	'The five %% boxing
 	wizards %% jump
 	quickly.';
 	```
@@ -254,9 +258,9 @@ The commented content is removed from the string’s cooked value.
 
 Multiline comments cannot be nested.
 ```
-'The \%% five \%% boxing %% wizards %% jump quickly.';
+'The %% five %% boxing %% wizards %% jump quickly.';
 ```
-> 'The  boxing %% wizards %% jump quickly.'
+> 'The  boxing  jump quickly.'
 
 
 ### String Templates
@@ -272,7 +276,7 @@ That’s about {{ 365 * years }} days.''';
 String templates may contain interpolated expressions, which are enclosed within double-braces `{{ … }}`.
 An interpolated expression is an expression that computes to a string.
 ```
-let twelve: string = '12!';
+let twelve: str = '12!';
 '''3 times 4 is {{ twelve }}''';
 ```
 > '3 times 4 is 12!'
@@ -312,8 +316,8 @@ Comments *within* string templates are *not* ignored.
 Sphinx of black quartz,    % not a comment
 judge my vow.              \% also not a comment
 
-Sphinx of    %% also not a comment %%        black quartz,
-judge        \%% and this isn’t either %%    my vow.
+Sphinx of    %% also not a comment %%           black quartz,
+judge        \%\% and this isn’t either \%\%    my vow.
 ''';
 ```
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -216,6 +216,48 @@ Other than for the special cases listed above, a backslash has no effect.
 >
 > 'Any non-special character may be escaped.'
 
+**There’s one exception to this rule:** The code `\%` does not escape a percent sign —
+it initiates a comment.
+
+#### In-String Comments
+String literals may contain Solid comments.
+Line comments begin with `\%` and continue until (but not including) the next line break, and
+multiline comments begin with `\%%` and continue until (and including) the next `%%`.
+Both kinds of comments will continue until their end delimiter unless the end of the string is reached first.
+The commented content is removed from the string’s cooked value.
+
+-
+	```
+	'The five boxing wizards \% jump quickly.';
+	```
+	> 'The five boxing wizards '
+-
+	```
+	'The five \% boxing wizards
+	jump quickly.';
+	```
+	> 'The five \
+	> jump quickly.'
+-
+	```
+	'The five \%% boxing wizards %% jump quickly.';
+	```
+	> 'The five  jump quickly.'
+-
+	```
+	'The five \%% boxing
+	wizards %% jump
+	quickly.';
+	```
+	> 'The five  jump\
+	> quickly.'
+
+Multiline comments cannot be nested.
+```
+'The \%% five \%% boxing %% wizards %% jump quickly.';
+```
+> 'The  boxing %% wizards %% jump quickly.'
+
 
 ### String Templates
 String templates are dynamic and may contain interpolated expressions.

--- a/docs/spec/grammar/lexicon.ebnf
+++ b/docs/spec/grammar/lexicon.ebnf
@@ -105,7 +105,9 @@ StringEscape :::=
 	| "'" | "\" | "s" | "t" | "n" | "r"
 	| "u{" DigitSequenceHex? "}"
 	| #x0a
-	| [^'\stnru#x0a#x03]
+	| "%" ([^'%#x0a#x03] [^'#x0a#x03]*)? #x0a?
+	| "%%" ("%"? [^'%#x03])* "%%"?
+	| [^'\stnru#x0a%#x03]
 ;
 
 

--- a/docs/spec/grammar/lexicon.ebnf
+++ b/docs/spec/grammar/lexicon.ebnf
@@ -112,15 +112,15 @@ StringChars :::=
 	| [^'\#x03]                StringChars?
 	| "\"         StringEscape StringChars?
 	| "\u"      ( [^'{#x03]    StringChars? )?
+	| "%" ([^'%#x0a#x03] [^'#x0a#x03]*)? #x0a?
+	| "%%" ("%"? [^'%#x03])* "%%"?
 ;
 
 StringEscape :::=
-	| "'" | "\" | "s" | "t" | "n" | "r"
+	| "'" | "%" | "\" | "s" | "t" | "n" | "r"
 	| "u{" DigitSequenceHex? "}"
 	| #x0a
-	| "%" ([^'%#x0a#x03] [^'#x0a#x03]*)? #x0a?
-	| "%%" ("%"? [^'%#x03])* "%%"?
-	| [^'\stnru#x0a%#x03]
+	| [^'%\stnru#x0a%#x03]
 ;
 
 

--- a/docs/spec/grammar/lexicon.ebnf
+++ b/docs/spec/grammar/lexicon.ebnf
@@ -120,7 +120,7 @@ StringEscape :::=
 	| "'" | "%" | "\" | "s" | "t" | "n" | "r"
 	| "u{" DigitSequenceHex? "}"
 	| #x0a
-	| [^'%\stnru#x0a%#x03]
+	| [^'%\stnru#x0a#x03]
 ;
 
 

--- a/docs/spec/grammar/lexicon.ebnf
+++ b/docs/spec/grammar/lexicon.ebnf
@@ -8,6 +8,19 @@ Whitespace
 
 
 
+Comment :::=
+	| CommentLine
+	| CommentMulti
+;
+
+CommentLine
+	:::= "%" ([^%#x0a#x03] [^#x0a#x03]*)? #x0a;
+
+CommentMulti
+	:::= "%%" ("%"? [^%#x03])* "%%";
+
+
+
 Punctuator :::=
 	// grouping
 		| "(" | ")"
@@ -157,22 +170,10 @@ TemplateChars__EndInterp__StartInterp :::=
 
 
 
-Comment :::=
-	| CommentLine
-	| CommentMulti
-;
-
-CommentLine
-	:::= "%" ([^%#x0a#x03] [^#x0a#x03]*)? #x0a;
-
-CommentMulti
-	:::= "%%" ("%"? [^%#x03])* "%%";
-
-
-
 Goal<Comment, Radix, Separator> :::=
 	| Filebound
 	| Whitespace
+	| <Comment+>Comment
 	| Punctuator
 	| Keyword
 	| Identifier
@@ -182,5 +183,4 @@ Goal<Comment, Radix, Separator> :::=
 	| TemplateHead
 	| TemplateMiddle
 	| TemplateTail
-	| <Comment+>Comment
 ;

--- a/docs/spec/grammar/tokenworth.ebnf
+++ b/docs/spec/grammar/tokenworth.ebnf
@@ -184,8 +184,14 @@ TokenWorth(StringEscape :::= "u{" DigitSequenceHex "}") -> Sequence<RealNumber>
 	:= [...UTF16Encoding(TokenWorth(DigitSequenceHex))];
 TokenWorth(StringEscape :::= #x0A) -> Sequence<RealNumber>
 	:= [\x20]; // U+0020 SPACE
-TokenWorth(StringEscape :::= [^'\stnru#x0D#x0A#x03]) -> Sequence<RealNumber>
-	:= [...UTF16Encoding(CodePoint([^'\stnru#x0D#x0A#x03]))];
+TokenWorth(StringEscape :::= "%" ([^'%#x0a#x03] [^'#x0a#x03]*)?) -> Sequence<RealNumber>
+	:= [];
+TokenWorth(StringEscape :::= "%" ([^'%#x0a#x03] [^'#x0a#x03]*)? #x0a) -> Sequence<RealNumber>
+	:= [\x0a];
+TokenWorth(StringEscape :::= "%%" ("%"? [^'%#x03])* "%%"?) -> Sequence<RealNumber>
+	:= [];
+TokenWorth(StringEscape :::= [^'\stnru#x0a%#x03]) -> Sequence<RealNumber>
+	:= UTF16Encoding(CodePoint([^'\stnru#x0a%#x03]));
 
 
 

--- a/docs/spec/grammar/tokenworth.ebnf
+++ b/docs/spec/grammar/tokenworth.ebnf
@@ -191,8 +191,8 @@ TokenWorth(StringEscape :::= "u{" DigitSequenceHex "}") -> Sequence<RealNumber>
 	:= [...UTF16Encoding(TokenWorth(DigitSequenceHex))];
 TokenWorth(StringEscape :::= #x0A) -> Sequence<RealNumber>
 	:= [\x20]; // U+0020 SPACE
-TokenWorth(StringEscape :::= [^'%\stnru#x0a%#x03]) -> Sequence<RealNumber>
-	:= UTF16Encoding(CodePoint([^'%\stnru#x0a%#x03]));
+TokenWorth(StringEscape :::= [^'%\stnru#x0a#x03]) -> Sequence<RealNumber>
+	:= UTF16Encoding(CodePoint([^'%\stnru#x0a#x03]));
 
 
 

--- a/docs/spec/grammar/tokenworth.ebnf
+++ b/docs/spec/grammar/tokenworth.ebnf
@@ -172,11 +172,18 @@ TokenWorth(StringChars :::= "\u" [^'{#x03']) -> Sequence<RealNumber>
 	:= [\x75, ...UTF16Encoding(CodePoint([^'{#x03']))];
 TokenWorth(StringChars :::= "\u" [^'{#x03'] StringChars) -> Sequence<RealNumber>
 	:= [\x75, ...UTF16Encoding(CodePoint([^'{#x03'])), ...TokenWorth(StringChars)];
+TokenWorth(StringChars :::= "%" ([^'%#x0a#x03] [^'#x0a#x03]*)?) -> Sequence<RealNumber>
+	:= [];
+TokenWorth(StringChars :::= "%" ([^'%#x0a#x03] [^'#x0a#x03]*)? #x0a) -> Sequence<RealNumber>
+	:= [\x0a]; // U+000A LINE FEED (LF)
+TokenWorth(StringChars :::= "%%" ("%"? [^'%#x03])* "%%"?) -> Sequence<RealNumber>
+	:= [];
 TokenWorth(StringEscape :::= "'") -> Sequence<RealNumber> := [\x27]; // U+0027 APOSTROPHE
+TokenWorth(StringEscape :::= "%") -> Sequence<RealNumber> := [\x25]; // U+0025 PERCENT SIGN
 TokenWorth(StringEscape :::= "\") -> Sequence<RealNumber> := [\x5c]; // U+005C REVERSE SOLIDUS
 TokenWorth(StringEscape :::= "s") -> Sequence<RealNumber> := [\x20]; // U+0020 SPACE
 TokenWorth(StringEscape :::= "t") -> Sequence<RealNumber> := [\x09]; // U+0009 CHARACTER TABULATION
-TokenWorth(StringEscape :::= "n") -> Sequence<RealNumber> := [\x0a]; // U+000A LINE FEED (LF)
+TokenWorth(StringEscape :::= "n") -> Sequence<RealNumber> := [\x0a];
 TokenWorth(StringEscape :::= "r") -> Sequence<RealNumber> := [\x0d]; // U+000D CARRIAGE RETURN (CR)
 TokenWorth(StringEscape :::= "u{" "}") -> Sequence<RealNumber>
 	:= [\x00]; // U+0000 NULL
@@ -184,14 +191,8 @@ TokenWorth(StringEscape :::= "u{" DigitSequenceHex "}") -> Sequence<RealNumber>
 	:= [...UTF16Encoding(TokenWorth(DigitSequenceHex))];
 TokenWorth(StringEscape :::= #x0A) -> Sequence<RealNumber>
 	:= [\x20]; // U+0020 SPACE
-TokenWorth(StringEscape :::= "%" ([^'%#x0a#x03] [^'#x0a#x03]*)?) -> Sequence<RealNumber>
-	:= [];
-TokenWorth(StringEscape :::= "%" ([^'%#x0a#x03] [^'#x0a#x03]*)? #x0a) -> Sequence<RealNumber>
-	:= [\x0a];
-TokenWorth(StringEscape :::= "%%" ("%"? [^'%#x03])* "%%"?) -> Sequence<RealNumber>
-	:= [];
-TokenWorth(StringEscape :::= [^'\stnru#x0a%#x03]) -> Sequence<RealNumber>
-	:= UTF16Encoding(CodePoint([^'\stnru#x0a%#x03]));
+TokenWorth(StringEscape :::= [^'%\stnru#x0a%#x03]) -> Sequence<RealNumber>
+	:= UTF16Encoding(CodePoint([^'%\stnru#x0a%#x03]));
 
 
 

--- a/docs/spec/language-lexicon.md
+++ b/docs/spec/language-lexicon.md
@@ -79,13 +79,13 @@ There are a small number of token types, each of which have a specific purpose.
 
 1. [File Bounds](#file-bounds)
 1. [Whitespace](#whitespace)
+1. [Comments](#comments)
 1. [Punctuators](#punctuators)
 1. [Keywords](#keywords)
 1. [Identifiers](#identifiers)
 1. [Numbers](#numbers)
 1. [String Literals](#string-literals)
 1. [Template Literals](#template-literals)
-1. [Comments](#comments)
 
 
 ### File Bounds
@@ -135,6 +135,27 @@ U+2029     | PARAGRAPH SEPARATOR       | General Punctuation         | Separator
 U+202F     | NARROW NO-BREAK SPACE     | General Punctuation         | Separator, Space [Zs]
 U+205F     | MEDIUM MATHEMATICAL SPACE | General Punctuation         | Separator, Space [Zs]
 U+3000     | IDEOGRAPHIC SPACE         | CJK Symbols and Punctuation | Separator, Space [Zs]
+
+
+### Comments
+Comments are tokens of arbitrary text,
+mainly used to add human-readable language to code
+or to provide other types of annotations.
+Comment tokens are not sent to the Solid parser.
+
+#### Line Comments
+Line comments begin with `%` (**U+0025 PERCENT SIGN**).
+The compiler will ignore all source text starting from `%` and onward,
+up to and including the next line break (**U+000A LINE FEED (LF)**).
+
+#### Multiline Comments
+Multiline comments are contained in the delimiters `%% %%`,
+and may contain line breaks. Nesting is not possible.
+
+##### Documentation Comments
+Documentation comments are multiline comments, but they use the delimiters `%%% %%`.
+The extra percent sign may signal to a separate parser that
+the comment documents the code structure that follows it.
 
 
 ### Punctuators
@@ -219,24 +240,3 @@ specific ways determined by the formal syntactic grammar.
 
 #### TokenWorth (Templates)
 The Token Worth of a Template token is the analogue of the Token Worth of a String token.
-
-
-### Comments
-Comments are tokens of arbitrary text,
-mainly used to add human-readable language to code
-or to provide other types of annotations.
-Comment tokens are not sent to the Solid parser.
-
-#### Line Comments
-Line comments begin with `%` (**U+0025 PERCENT SIGN**).
-The compiler will ignore all source text starting from `%` and onward,
-up to and including the next line break (**U+000A LINE FEED (LF)**).
-
-#### Multiline Comments
-Multiline comments are contained in the delimiters `%% %%`,
-and may contain line breaks. Nesting is not possible.
-
-##### Documentation Comments
-Documentation comments are multiline comments, but they use the delimiters `%%% %%`.
-The extra percent sign may signal to a separate parser that
-the comment documents the code structure that follows it.

--- a/src/parser/Token.ts
+++ b/src/parser/Token.ts
@@ -95,6 +95,29 @@ export type CookValueType = string|number|bigint|boolean|null
 
 
 
+export class TokenCommentLine extends TokenComment {
+	static readonly DELIM_START: '%'  = '%'
+	static readonly DELIM_END:   '\n' = '\n'
+	constructor (lexer: Lexer) {
+		super(lexer, TokenCommentLine.DELIM_START, TokenCommentLine.DELIM_END)
+	}
+	protected stopAdvancing() {
+		return Char.eq(TokenCommentLine.DELIM_END, this.lexer.c0)
+	}
+}
+export class TokenCommentMulti extends TokenComment {
+	static readonly DELIM_START: '%%' = '%%'
+	static readonly DELIM_END:   '%%' = '%%'
+	constructor (lexer: Lexer) {
+		super(lexer, TokenCommentMulti.DELIM_START, TokenCommentMulti.DELIM_END)
+	}
+	protected stopAdvancing() {
+		return Char.eq(TokenCommentMulti.DELIM_END, this.lexer.c0, this.lexer.c1)
+	}
+}
+
+
+
 export abstract class TokenSolid extends Token {
 	/**
 	 * Return this Token’s cooked value.
@@ -597,25 +620,5 @@ export class TokenTemplate extends TokenSolid {
 		return String.fromCharCode(...TokenTemplate.tokenWorth(
 			this.source.slice(this.delim_start.length, -this.delim_end.length) // cut off the template delimiters
 		))
-	}
-}
-export class TokenCommentLine extends TokenComment {
-	static readonly DELIM_START: '%'  = '%'
-	static readonly DELIM_END:   '\n' = '\n'
-	constructor (lexer: Lexer) {
-		super(lexer, TokenCommentLine.DELIM_START, TokenCommentLine.DELIM_END)
-	}
-	protected stopAdvancing() {
-		return Char.eq(TokenCommentLine.DELIM_END, this.lexer.c0)
-	}
-}
-export class TokenCommentMulti extends TokenComment {
-	static readonly DELIM_START: '%%' = '%%'
-	static readonly DELIM_END:   '%%' = '%%'
-	constructor (lexer: Lexer) {
-		super(lexer, TokenCommentMulti.DELIM_START, TokenCommentMulti.DELIM_END)
-	}
-	protected stopAdvancing() {
-		return Char.eq(TokenCommentMulti.DELIM_END, this.lexer.c0, this.lexer.c1)
 	}
 }


### PR DESCRIPTION
In-string comments are comment syntax inside string literals. They do not apply to template literals. In-string comments are ignored by the “token cooker” and are not included as part of the token’s string value. See documentation in this PR for details. Revises #5 and #7.