### PR TITLE
Type Claim Expressions

### DIFF
--- a/docs/reference/expressions-operators.md
+++ b/docs/reference/expressions-operators.md
@@ -78,13 +78,20 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 		</tr>
 		<tr>
 			<th>4</th>
+			<td>Type Claim</td>
+			<td>unary prefix</td>
+			<td>right-to-left</td>
+			<td><code>&lt; … &gt; …</code></td>
+		</tr>
+		<tr>
+			<th>5</th>
 			<td>Exponentiation</td>
 			<td>binary infix</td>
 			<td>right-to-left</td>
 			<td><code>… ^ …</code></td>
 		</tr>
 		<tr>
-			<th rowspan="2">5</th>
+			<th rowspan="2">6</th>
 			<td>Multiplication</td>
 			<td rowspan="2">binary infix</td>
 			<td rowspan="2">left-to-right</td>
@@ -95,7 +102,7 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 			<td><code>… / …</code></td>
 		</tr>
 		<tr>
-			<th rowspan="2">6</th>
+			<th rowspan="2">7</th>
 			<td>Addition</td>
 			<td rowspan="2">binary infix</td>
 			<td rowspan="2">left-to-right</td>
@@ -106,7 +113,7 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 			<td><code>… - …</code></td>
 		</tr>
 		<tr>
-			<th rowspan="8">7</th>
+			<th rowspan="8">8</th>
 			<td>Less Than</td>
 			<td rowspan="8">binary infix</td>
 			<td rowspan="8">left-to-right</td>
@@ -141,7 +148,7 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 			<td><code>… isnt …</code></td>
 		</tr>
 		<tr>
-			<th rowspan="4">8</th>
+			<th rowspan="4">9</th>
 			<td>Identity</td>
 			<td rowspan="4">binary infix</td>
 			<td rowspan="4">left-to-right</td>
@@ -160,7 +167,7 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 			<td><code>… != …</code></td>
 		</tr>
 		<tr>
-			<th rowspan="2">9</th>
+			<th rowspan="2">10</th>
 			<td>Conjunction</td>
 			<td rowspan="2">binary infix</td>
 			<td rowspan="2">left-to-right</td>
@@ -171,7 +178,7 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 			<td><code>… !& …</code></td>
 		</tr>
 		<tr>
-			<th rowspan="2">10</th>
+			<th rowspan="2">11</th>
 			<td>Disjunction</td>
 			<td rowspan="2">binary infix</td>
 			<td rowspan="2">left-to-right</td>
@@ -182,7 +189,7 @@ In the table below, the horizontal ellipsis character `…` represents an allowe
 			<td><code>… !| …</code></td>
 		</tr>
 		<tr>
-			<th>11</th>
+			<th>12</th>
 			<td>Conditional</td>
 			<td>ternary infix</td>
 			<td>n/a</td>
@@ -353,6 +360,54 @@ Even though these tokens’ values are the same as the computed values of
 the expressions `-(\x200)` and `+(\x200)`,
 this is important to mention because it could affect how we write
 [additive expressions](#parsing-additive-expressions).
+
+
+### Type Claim
+```
+`<` <Type> `>` <obj>
+```
+The expression `<T>expr` tells the type system to treat `expr` as type `T`,
+even though it might have been computed as a different type.
+This is called a **type claim**, because we’re *claiming* that `expr` is of type `T`.
+
+Normally, the compiler will compute the type of an expression, but sometimes the compiler gets it wrong,
+or we as programmers know more than the compiler does, based on conditions or circumstances of our code.
+We can use a claim to tell the compiler, “I know what I’m doing and the type should be *that*.”
+
+Type claims are a general form of [Claim Access](#claim-access).
+For example, we could use claim access to say that an optional entry exists on an object:
+```
+let unfixed item: [str, ?: int] = ['apples', 42];
+let quantity: int = item!.1;
+```
+The more general form of this is claiming that `item.1` is of type `int`:
+```
+let unfixed item: [str, ?: int] = ['apples', 42];
+let quantity: int = <int>item.1;
+```
+
+Type claims can be used in situations where claim access cannot.
+Whereas claim access can only tell the compiler that a property *exists*,
+type claims can widen, narrow, or shift the type of an expression.
+```
+let unfixed item: [str, int | str] = ['apples', 42];
+let ingredient: obj        = <obj>item.0;        % widening
+let quantity:   int        = <int>item.1;        % narrowing
+let in_stock:   int | bool = <int | bool>item.1; % shifting
+```
+
+The compiler will throw an error when encountering a type claim if its operand’s computed type
+and its claimed type are disjoint (i.e. if there’s no overlap).
+```
+<str>42; %> TypeError
+```
+
+A note of caution: Like claim access, **type claims should never be used to “hack” the compiler**.
+Using type claims to “just get your code to compile” is never recommended,
+because it won’t prevent runtime errors and it will most likely cause more problems down the road.
+But there are cases in which human reasoning about type safety outsmarts the compiler,
+so in those cases we may use type claims to write good code.
+
 
 
 ### Exponentiation

--- a/docs/reference/expressions-operators.md
+++ b/docs/reference/expressions-operators.md
@@ -369,6 +369,7 @@ this is important to mention because it could affect how we write
 The expression `<T>expr` tells the type system to treat `expr` as type `T`,
 even though it might have been computed as a different type.
 This is called a **type claim**, because we’re *claiming* that `expr` is of type `T`.
+(We say “claim” instead of “assert”, which is an unrelated concept.)
 
 Normally, the compiler will compute the type of an expression, but sometimes the compiler gets it wrong,
 or we as programmers know more than the compiler does, based on conditions or circumstances of our code.

--- a/docs/spec/grammar-solid/ValueOf.ebnf
+++ b/docs/spec/grammar-solid/ValueOf.ebnf
@@ -168,6 +168,13 @@ Object! ValueOf(SemanticCall call) :=
 
 
 
+Object! ValueOf(SemanticClaim claim) :=
+	1. *Assert:* `claim.children.count` is 2.
+	2. *Return:* `ValueOf(claim.children.1)`.
+;
+
+
+
 Boolean! ValueOf(SemanticOperation[operator: NOT] expr) :=
 	1. *Assert:* `expr.children.count` is 1.
 	2. *Let* `operand` be *Unwrap:* `ValueOf(expr.children.0)`.

--- a/docs/spec/grammar-solid/build.ebnf
+++ b/docs/spec/grammar-solid/build.ebnf
@@ -92,6 +92,13 @@ Sequence<Instruction> BuildExpression(SemanticTemplate tpl) :=
 
 
 
+Sequence<Instruction> BuildExpression(SemanticClaim claim) :=
+	1. *Assert:* `claim.children.count` is 2.
+	2. *Return:* `Build(expr.children.1)`.
+;
+
+
+
 Sequence<Instruction> BuildExpression(SemanticOperation[operator: NOT | EMP | NEG] expr) :=
 	1. *Assert:* `expr.children.count` is 1.
 	2. *Let* `instrs` be *UnwrapAffirm:* `Build(expr.children.0)`.

--- a/docs/spec/grammar-solid/build.ebnf
+++ b/docs/spec/grammar-solid/build.ebnf
@@ -94,7 +94,7 @@ Sequence<Instruction> BuildExpression(SemanticTemplate tpl) :=
 
 Sequence<Instruction> BuildExpression(SemanticClaim claim) :=
 	1. *Assert:* `claim.children.count` is 2.
-	2. *Return:* `Build(expr.children.1)`.
+	2. *Return:* `Build(claim.children.1)`.
 ;
 
 

--- a/docs/spec/grammar-solid/decorate.ebnf
+++ b/docs/spec/grammar-solid/decorate.ebnf
@@ -381,11 +381,21 @@ Decorate(ExpressionUnarySymbol ::= "-" ExpressionUnarySymbol) -> SemanticOperati
 
 
 
-Decorate(ExpressionExponential ::= ExpressionUnarySymbol) -> SemanticExpression
+Decorate(ExpressionClaim ::= ExpressionUnarySymbol) -> SemanticExpression
 	:= Decorate(ExpressionUnarySymbol);
-Decorate(ExpressionExponential ::= ExpressionUnarySymbol "^" ExpressionExponential) -> SemanticOperation
+Decorate(ExpressionClaim ::= "<" Type ">" ExpressionClaim) -> SemanticClaim
+	:= (SemanticClaim
+		Decorate(Type)
+		Decorate(ExpressionClaim)
+	);
+
+
+
+Decorate(ExpressionExponential ::= ExpressionClaim) -> SemanticExpression
+	:= Decorate(ExpressionClaim);
+Decorate(ExpressionExponential ::= ExpressionClaim "^" ExpressionExponential) -> SemanticOperation
 	:= (SemanticOperation[operator=EXP]
-		Decorate(ExpressionUnarySymbol)
+		Decorate(ExpressionClaim)
 		Decorate(ExpressionExponential)
 	);
 

--- a/docs/spec/grammar-solid/semantics.ebnf
+++ b/docs/spec/grammar-solid/semantics.ebnf
@@ -78,6 +78,7 @@ SemanticExpression =:=
 	| SemanticMap
 	| SemanticCall
 	| SemanticAccess
+	| SemanticClaim
 	| SemanticOperation
 ;
 
@@ -105,6 +106,9 @@ SemanticAccess[kind: NORMAL | OPTIONAL | CLAIM]
 
 SemanticCall
 	::= SemanticExpression SemanticType* SemanticExpression*;
+
+SemanticClaim
+	::= SemanticType SemanticExpression;
 
 SemanticOperation[operator: NOT | EMP]
 	::= SemanticExpression;

--- a/docs/spec/grammar-solid/syntax.ebnf
+++ b/docs/spec/grammar-solid/syntax.ebnf
@@ -131,13 +131,11 @@ Assignee ::=
 	| ExpressionCompound PropertyAssign
 ;
 
-ExpressionUnarySymbol ::=
-	| ExpressionCompound
-	| ("!" | "?" | "+" | "-") ExpressionUnarySymbol
-;
+ExpressionUnarySymbol ::= ExpressionCompound    | ("!" | "?" | "+" | "-") ExpressionUnarySymbol;
+ExpressionClaim       ::= ExpressionUnarySymbol | "<" Type ">"            ExpressionClaim;
 
 ExpressionExponential
-	::= ExpressionUnarySymbol ("^" ExpressionExponential)?;
+	::= ExpressionClaim ("^" ExpressionExponential)?;
 
 ExpressionMultiplicative ::= (ExpressionMultiplicative ("*" | "/" ))?                                            ExpressionExponential;
 ExpressionAdditive       ::= (ExpressionAdditive       ("+" | "-" ))?                                            ExpressionMultiplicative;

--- a/docs/spec/grammar-solid/typeof.ebnf
+++ b/docs/spec/grammar-solid/typeof.ebnf
@@ -219,6 +219,18 @@ Type! TypeOfUnfolded(SemanticCall call) :=
 
 
 
+Type! TypeOf(SemanticClaim claim) :=
+	1. *Note:* This algorithm overrides `TypeOf(SemanticExpression)`.
+	2. *Assert:* `claim.children.count` is 2.
+	3. Let `claimed_type` be `TypeValueOf(claim.children.0)`.
+	4. Let `computed_type` be `TypeOf(claim.children.1)`.
+	5. *If* `Intersect(claimed_type, computed_type)` is `never`:
+		1. *Throw:* a new TypeError03.
+	6. Return `claimed_type`.
+;
+
+
+
 Type! TypeOfUnfolded(SemanticOperation[operator: NOT] expr) :=
 	1. *Assert:* `expr.children.count` is 1.
 	2. *Let* `operand` be *Unwrap:* `TypeOf(expr.children.0)`.

--- a/src/parser/ParserSolid.ts
+++ b/src/parser/ParserSolid.ts
@@ -536,12 +536,22 @@ class ProductionExpressionUnarySymbol extends Production {
 	}
 }
 
+class ProductionExpressionClaim extends Production {
+	static readonly instance: ProductionExpressionClaim = new ProductionExpressionClaim();
+	override get sequences(): NonemptyArray<NonemptyArray<GrammarSymbol>> {
+		return [
+			[ProductionExpressionUnarySymbol.instance],
+			['<', ProductionType.instance, '>', ProductionExpressionClaim.instance],
+		];
+	}
+}
+
 class ProductionExpressionExponential extends Production {
 	static readonly instance: ProductionExpressionExponential = new ProductionExpressionExponential();
 	override get sequences(): NonemptyArray<NonemptyArray<GrammarSymbol>> {
 		return [
-			[ProductionExpressionUnarySymbol.instance],
-			[ProductionExpressionUnarySymbol.instance, '^', ProductionExpressionExponential.instance],
+			[ProductionExpressionClaim.instance],
+			[ProductionExpressionClaim.instance, '^', ProductionExpressionExponential.instance],
 		];
 	}
 }
@@ -1095,10 +1105,17 @@ export class ParseNodeExpressionUnarySymbol extends ParseNode {
 	;
 }
 
-export class ParseNodeExpressionExponential extends ParseNode {
+export class ParseNodeExpressionClaim extends ParseNode {
 	declare readonly children:
 		| readonly [ParseNodeExpressionUnarySymbol]
-		| readonly [ParseNodeExpressionUnarySymbol, Token, ParseNodeExpressionExponential]
+		| readonly [Token, ParseNodeType, Token, ParseNodeExpressionClaim]
+	;
+}
+
+export class ParseNodeExpressionExponential extends ParseNode {
+	declare readonly children:
+		| readonly [ParseNodeExpressionClaim]
+		| readonly [ParseNodeExpressionClaim, Token, ParseNodeExpressionExponential]
 	;
 }
 
@@ -1268,6 +1285,7 @@ export const GRAMMAR: Grammar = new Grammar([
 	ProductionExpressionCompound.instance,
 	ProductionAssignee.instance,
 	ProductionExpressionUnarySymbol.instance,
+	ProductionExpressionClaim.instance,
 	ProductionExpressionExponential.instance,
 	ProductionExpressionMultiplicative.instance,
 	ProductionExpressionAdditive.instance,
@@ -1340,6 +1358,7 @@ export class ParserSolid extends Parser<ParseNodeGoal> {
 		[ProductionExpressionCompound.instance, ParseNodeExpressionCompound],
 		[ProductionAssignee.instance, ParseNodeAssignee],
 		[ProductionExpressionUnarySymbol.instance, ParseNodeExpressionUnarySymbol],
+		[ProductionExpressionClaim.instance, ParseNodeExpressionClaim],
 		[ProductionExpressionExponential.instance, ParseNodeExpressionExponential],
 		[ProductionExpressionMultiplicative.instance, ParseNodeExpressionMultiplicative],
 		[ProductionExpressionAdditive.instance, ParseNodeExpressionAdditive],

--- a/src/validator/DecoratorSolid.ts
+++ b/src/validator/DecoratorSolid.ts
@@ -128,6 +128,7 @@ class DecoratorSolid extends Decorator {
 		| PARSENODE.ParseNodeExpressionUnit
 		| PARSENODE.ParseNodeExpressionCompound
 		| PARSENODE.ParseNodeExpressionUnarySymbol
+		| PARSENODE.ParseNodeExpressionClaim
 		| PARSENODE.ParseNodeExpressionExponential
 		| PARSENODE.ParseNodeExpressionMultiplicative
 		| PARSENODE.ParseNodeExpressionAdditive
@@ -390,6 +391,11 @@ class DecoratorSolid extends Decorator {
 						DecoratorSolid.OPERATORS_UNARY.get(node.children[0].source as Punctuator) as ValidOperatorUnary,
 						this.decorate(node.children[1]),
 					);
+
+		} else if (node instanceof PARSENODE.ParseNodeExpressionClaim) {
+			return (node.children.length === 1)
+				? this.decorate(node.children[0])
+				: new AST.ASTNodeClaim(node, this.decorate(node.children[1]), this.decorate(node.children[3]));
 
 		} else if (
 			node instanceof PARSENODE.ParseNodeExpressionExponential    ||

--- a/src/validator/astnode-solid/ASTNodeClaim.ts
+++ b/src/validator/astnode-solid/ASTNodeClaim.ts
@@ -46,7 +46,14 @@ export class ASTNodeClaim extends ASTNodeExpression {
 	protected override type_do(): SolidType {
 		const claimed_type:  SolidType = this.claimed_type.eval();
 		const computed_type: SolidType = this.operand.type();
-		if (claimed_type.intersect(computed_type).equals(SolidType.NEVER)) {
+		const is_intersection_empty: boolean = claimed_type.intersect(computed_type).equals(SolidType.NEVER);
+		const treatIntAsSubtypeOfFloat: boolean = this.validator.config.compilerOptions.intCoercion && (
+			   computed_type.isSubtypeOf(SolidType.INT) && SolidType.FLOAT.isSubtypeOf(claimed_type)
+			|| claimed_type.isSubtypeOf(SolidType.INT)  && SolidType.FLOAT.isSubtypeOf(computed_type)
+			|| SolidType.INT.isSubtypeOf(computed_type) && claimed_type.isSubtypeOf(SolidType.FLOAT)
+			|| SolidType.INT.isSubtypeOf(claimed_type)  && computed_type.isSubtypeOf(SolidType.FLOAT)
+		);
+		if (is_intersection_empty && !treatIntAsSubtypeOfFloat) {
 			/*
 				`Conversion of type \`${ computed_type }\` to type \`${ claimed_type }\` may be a mistake
 				because neither type sufficiently overlaps with the other. If this was intentional,

--- a/src/validator/astnode-solid/ASTNodeClaim.ts
+++ b/src/validator/astnode-solid/ASTNodeClaim.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+import {
+	SolidType,
+	SolidObject,
+	INST,
+	Builder,
+	SolidConfig,
+	CONFIG_DEFAULT,
+	ParseNode,
+} from './package.js';
+import type {ASTNodeType} from './ASTNodeType.js';
+import {ASTNodeExpression} from './ASTNodeExpression.js';
+
+
+
+
+export class ASTNodeClaim extends ASTNodeExpression {
+	static override fromSource(src: string, config: SolidConfig = CONFIG_DEFAULT): ASTNodeClaim {
+		const expression: ASTNodeExpression = ASTNodeExpression.fromSource(src, config);
+		assert.ok(expression instanceof ASTNodeClaim);
+		return expression;
+	}
+	constructor(
+		start_node: ParseNode,
+		readonly claimed_type: ASTNodeType,
+		readonly operand: ASTNodeExpression,
+	) {
+		super(start_node, {}, [claimed_type, operand]);
+	}
+	override shouldFloat(): boolean {
+		throw 'TODO';
+	}
+	protected override build_do(builder: Builder, to_float: boolean = false): INST.InstructionExpression {
+		throw builder && to_float && 'TODO';
+	}
+	protected override type_do(): SolidType {
+		throw 'TODO';
+	}
+	protected override fold_do(): SolidObject | null {
+		throw 'TODO';
+	}
+}

--- a/src/validator/astnode-solid/ASTNodeExpression.ts
+++ b/src/validator/astnode-solid/ASTNodeExpression.ts
@@ -28,6 +28,7 @@ import {ASTNodeSolid} from './ASTNodeSolid.js';
  * - ASTNodeCollectionLiteral
  * - ASTNodeAccess
  * - ASTNodeCall
+ * - ASTNodeClaim
  * - ASTNodeOperation
  */
 export abstract class ASTNodeExpression extends ASTNodeSolid implements Buildable {

--- a/src/validator/astnode-solid/index.ts
+++ b/src/validator/astnode-solid/index.ts
@@ -31,6 +31,7 @@ export * from './ASTNodeSet.js';
 export * from './ASTNodeMap.js';
 export * from './ASTNodeAccess.js';
 export * from './ASTNodeCall.js';
+export * from './ASTNodeClaim.js';
 export * from './ASTNodeOperation.js';
 export * from './ASTNodeOperationUnary.js';
 export * from './ASTNodeOperationBinary.js';

--- a/test/helpers-parse.ts
+++ b/test/helpers-parse.ts
@@ -192,6 +192,11 @@ export function compoundExpressionFromSource(src: string, config: SolidConfig = 
 	return expression_unary.children[0];
 }
 export function unaryExpressionFromSource(src: string, config: SolidConfig = CONFIG_DEFAULT): PARSENODE.ParseNodeExpressionUnarySymbol {
+	const expression_claim: PARSENODE.ParseNodeExpressionClaim = claimExpressionFromSource(src, config);
+	assert_arrayLength(expression_claim.children, 1, 'claim expression should have 1 child');
+	return expression_claim.children[0];
+}
+export function claimExpressionFromSource(src: string, config: SolidConfig = CONFIG_DEFAULT): PARSENODE.ParseNodeExpressionClaim {
 	const expression_exp: PARSENODE.ParseNodeExpressionExponential = exponentialExpressionFromSource(src, config)
 	assert_arrayLength(expression_exp.children, 1, 'exponential expression should have 1 child')
 	return expression_exp.children[0]

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,6 +18,23 @@ export const CONFIG_FOLDING_OFF: SolidConfig = {
 	},
 };
 
+export const CONFIG_COERCION_OFF: SolidConfig = {
+	...CONFIG_DEFAULT,
+	compilerOptions: {
+		...CONFIG_DEFAULT.compilerOptions,
+		intCoercion: false,
+	},
+};
+
+export const CONFIG_FOLDING_COERCION_OFF: SolidConfig = {
+	...CONFIG_DEFAULT,
+	compilerOptions: {
+		...CONFIG_DEFAULT.compilerOptions,
+		constantFolding: false,
+		intCoercion:     false,
+	},
+};
+
 
 
 export function typeConstInt(x: bigint): SolidTypeUnit {

--- a/test/parser/Parser.test.ts
+++ b/test/parser/Parser.test.ts
@@ -623,18 +623,38 @@ describe('ParserSolid', () => {
 			});
 		});
 
-		context('ExpressionExponential ::=  ExpressionUnarySymbol "^" ExpressionExponential', () => {
+		specify('ExpressionClaim ::= "<" Type ">" ExpressionClaim', () => {
+			/*
+				<ExpressionClaim>
+					<PUNCTUATOR>&lt;</PUNCTUATOR>
+					<Type source="float">...</Type>
+					<PUNCTUATOR>&gt;</PUNCTUATOR>
+					<ExpressionClaim source="3">...</ExpressionClaim>
+				</ExpressionClaim>
+			*/
+			const expression_claim: PARSENODE_SOLID.ParseNodeExpressionClaim = h.claimExpressionFromSource(`<float>3;`);
+			assert_arrayLength(expression_claim.children, 4, 'claim expression should have 4 children');
+			const [ang_opn, typ, ang_cls, expr]: readonly [Token, PARSENODE_SOLID.ParseNodeType, Token, PARSENODE_SOLID.ParseNodeExpressionClaim] = expression_claim.children;
+			assert.ok(ang_opn instanceof TOKEN.TokenPunctuator);
+			assert.ok(ang_cls instanceof TOKEN.TokenPunctuator);
+			assert.deepStrictEqual(
+				[ang_opn.source, typ.source, ang_cls.source, expr.source],
+				[Punctuator.LT,  'float',    Punctuator.GT,  '3'],
+			);
+		});
+
+		context('ExpressionExponential ::= ExpressionClaim "^" ExpressionExponential', () => {
 			it('makes a ParseNodeExpressionExponential node.', () => {
 				/*
 					<ExpressionExponential>
-						<ExpressionUnarySymbol source="2">...</ExpressionUnarySymbol>
+						<ExpressionClaim source="2">...</ExpressionClaim>
 						<PUNCTUATOR>^</PUNCTUATOR>
 						<ExpressionExponential source="-3">...</ExpressionExponential>
 					</ExpressionExponential>
 				*/
 				const expression_exp: PARSENODE_SOLID.ParseNodeExpressionExponential = h.exponentialExpressionFromSource(`2 ^ -3;`);
 				assert_arrayLength(expression_exp.children, 3, 'exponential expression should have 3 children')
-				const [left, op, right]: readonly [PARSENODE_SOLID.ParseNodeExpressionUnarySymbol, Token, PARSENODE_SOLID.ParseNodeExpressionExponential] = expression_exp.children;
+				const [left, op, right]: readonly [PARSENODE_SOLID.ParseNodeExpressionClaim, Token, PARSENODE_SOLID.ParseNodeExpressionExponential] = expression_exp.children;
 				assert.ok(op instanceof TOKEN.TokenPunctuator)
 				assert.deepStrictEqual(
 					[left.source, op.source,      right.source],

--- a/test/validator/DecoratorSolid.test.ts
+++ b/test/validator/DecoratorSolid.test.ts
@@ -999,7 +999,7 @@ describe('DecoratorSolid', () => {
 			})
 		})
 
-		context('ExpressionExponential ::= ExpressionUnarySymbol ("^" ExpressionExponential)?', () => {
+		context('ExpressionExponential ::= ExpressionClaim ("^" ExpressionExponential)?', () => {
 			it('makes an ASTNodeOperationBinary.', () => {
 				/*
 					<Operation operator=EXP>

--- a/test/validator/DecoratorSolid.test.ts
+++ b/test/validator/DecoratorSolid.test.ts
@@ -999,6 +999,23 @@ describe('DecoratorSolid', () => {
 			})
 		})
 
+		context('ExpressionClaim ::= "<" Type ">" ExpressionClaim', () => {
+			it('makes an ASTNodeClaim.', () => {
+				/*
+					<Claim>
+						<TypeConstant source="float"/>
+						<Constant source="3"/>
+					</Claim>
+				*/
+				const claim: AST.ASTNodeExpression = DECORATOR_SOLID.decorate(h.claimExpressionFromSource(`<float>3;`));
+				assert.ok(claim instanceof AST.ASTNodeClaim);
+				assert.ok(claim.claimed_type instanceof AST.ASTNodeTypeConstant);
+				assert.ok(claim.operand      instanceof AST.ASTNodeConstant);
+				assert.strictEqual(claim.claimed_type.source, `float`);
+				assert.strictEqual(claim.operand.source,      `3`);
+			});
+		});
+
 		context('ExpressionExponential ::= ExpressionClaim ("^" ExpressionExponential)?', () => {
 			it('makes an ASTNodeOperationBinary.', () => {
 				/*

--- a/test/validator/astnode-solid/ASTNodeDeclarationVariable.test.ts
+++ b/test/validator/astnode-solid/ASTNodeDeclarationVariable.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../assert-helpers.js';
 import {
 	CONFIG_FOLDING_OFF,
+	CONFIG_COERCION_OFF,
 	instructionConstInt,
 	instructionConstFloat,
 	typeConstInt,
@@ -171,13 +172,7 @@ describe('ASTNodeDeclarationVariable', () => {
 		it('with int coersion off, throws when assigning int to float.', () => {
 			assert.throws(() => AST.ASTNodeDeclarationVariable.fromSource(`
 				let x: float = 42;
-			`, {
-				...CONFIG_DEFAULT,
-				compilerOptions: {
-					...CONFIG_DEFAULT.compilerOptions,
-					intCoercion: false,
-				},
-			}).typeCheck(), TypeError03);
+			`, CONFIG_COERCION_OFF).typeCheck(), TypeError03);
 		})
 		it('with constant folding on, only sets `SymbolStructure#value` if type is immutable and variable is fixed.', () => {
 			const goal: AST.ASTNodeGoal = AST.ASTNodeGoal.fromSource(abcde);

--- a/test/validator/astnode-solid/ASTNodeExpression.test.ts
+++ b/test/validator/astnode-solid/ASTNodeExpression.test.ts
@@ -25,6 +25,7 @@ import {
 	ReferenceError01,
 	ReferenceError02,
 	ReferenceError03,
+	TypeError03,
 } from '../../../src/index.js';
 import {assert_wasCalled} from '../../assert-helpers.js';
 import {
@@ -505,6 +506,65 @@ describe('ASTNodeExpression', () => {
 				);
 			});
 			// TODO: SolidSet overwrites duplicate elements. // move this to SolidType.test.ts
+		});
+	});
+
+
+
+	describe('ASTNodeConstant', () => {
+		const samples: string[] = [
+			`null;`,
+			`false;`,
+			`true;`,
+			`0;`,
+			`+0;`,
+			`-0;`,
+			`42;`,
+			`+42;`,
+			`-42;`,
+			`0.0;`,
+			`+0.0;`,
+			`-0.0;`,
+			`-4.2e-2;`,
+		];
+		describe('#type', () => {
+			it('returns the type value of the claimed type.', () => {
+				assert.ok(AST.ASTNodeClaim.fromSource(`<int?>3;`).type().equals(SolidType.INT.union(SolidType.NULL)));
+			});
+			it('throws when the operand type and claimed type do not overlap.', () => {
+				assert.throws(() => AST.ASTNodeClaim.fromSource(`<float>3;`)    .type(), TypeError03);
+				assert.throws(() => AST.ASTNodeClaim.fromSource(`<int>3.0;`)    .type(), TypeError03);
+				assert.throws(() => AST.ASTNodeClaim.fromSource(`<str>3;`)      .type(), TypeError03);
+				assert.throws(() => AST.ASTNodeClaim.fromSource(`<int>'three';`).type(), TypeError03);
+			});
+		});
+
+
+		describe('#fold', () => {
+			it('returns the fold of the operand.', () => {
+				samples.forEach((expr) => {
+					const src: string = `<obj>${ expr }`;
+					assert.deepStrictEqual(
+						AST.ASTNodeClaim     .fromSource(src) .fold(),
+						AST.ASTNodeExpression.fromSource(expr).fold(),
+						expr,
+					);
+				});
+			});
+		});
+
+
+		describe('#build', () => {
+			it('returns the build of the operand.', () => {
+				samples.forEach((expr) => {
+					const src: string = `<obj>${ expr }`;
+					assert.deepStrictEqual(
+						AST.ASTNodeClaim     .fromSource(src) .build(new Builder(src)),
+						AST.ASTNodeExpression.fromSource(expr).build(new Builder(expr)),
+						expr,
+					);
+				});
+			});
 		});
 	});
 });

--- a/test/validator/astnode-solid/ASTNodeExpression.test.ts
+++ b/test/validator/astnode-solid/ASTNodeExpression.test.ts
@@ -30,6 +30,7 @@ import {
 import {assert_wasCalled} from '../../assert-helpers.js';
 import {
 	CONFIG_FOLDING_OFF,
+	CONFIG_COERCION_OFF,
 	typeConstInt,
 	typeConstFloat,
 	typeConstStr,
@@ -511,7 +512,7 @@ describe('ASTNodeExpression', () => {
 
 
 
-	describe('ASTNodeConstant', () => {
+	describe('ASTNodeClaim', () => {
 		const samples: string[] = [
 			`null;`,
 			`false;`,
@@ -532,10 +533,14 @@ describe('ASTNodeExpression', () => {
 				assert.ok(AST.ASTNodeClaim.fromSource(`<int?>3;`).type().equals(SolidType.INT.union(SolidType.NULL)));
 			});
 			it('throws when the operand type and claimed type do not overlap.', () => {
-				assert.throws(() => AST.ASTNodeClaim.fromSource(`<float>3;`)    .type(), TypeError03);
-				assert.throws(() => AST.ASTNodeClaim.fromSource(`<int>3.0;`)    .type(), TypeError03);
 				assert.throws(() => AST.ASTNodeClaim.fromSource(`<str>3;`)      .type(), TypeError03);
 				assert.throws(() => AST.ASTNodeClaim.fromSource(`<int>'three';`).type(), TypeError03);
+			});
+			it('with int coersion off, does not allow converting between int and float.', () => {
+				AST.ASTNodeClaim.fromSource(`<float>3;`).type(); // assert does not throw
+				AST.ASTNodeClaim.fromSource(`<int>3.0;`).type(); // assert does not throw
+				assert.throws(() => AST.ASTNodeClaim.fromSource(`<float>3;`, CONFIG_COERCION_OFF).type(), TypeError03);
+				assert.throws(() => AST.ASTNodeClaim.fromSource(`<int>3.0;`, CONFIG_COERCION_OFF).type(), TypeError03);
 			});
 		});
 

--- a/test/validator/astnode-solid/ASTNodeOperation.test.ts
+++ b/test/validator/astnode-solid/ASTNodeOperation.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../assert-helpers.js';
 import {
 	CONFIG_FOLDING_OFF,
+	CONFIG_FOLDING_COERCION_OFF,
 	typeConstInt,
 	typeConstFloat,
 	typeConstStr,
@@ -31,14 +32,6 @@ import {
 
 
 
-const CONFIG_FOLDING_COERCION_OFF: SolidConfig = {
-	...CONFIG_DEFAULT,
-	compilerOptions: {
-		...CONFIG_DEFAULT.compilerOptions,
-		constantFolding: false,
-		intCoercion: false,
-	},
-};
 function typeOperations(tests: ReadonlyMap<string, SolidObject>, config: SolidConfig = CONFIG_DEFAULT): void {
 	return assert.deepStrictEqual(
 		[...tests.keys()].map((src) => AST.ASTNodeOperation.fromSource(src, config).type()),


### PR DESCRIPTION
The expression `<T>expr` tells the type system to treat `expr` as type `T`, even though it might have been computed as a different type. This is called a **type claim**, because we’re *claiming* that `expr` is of type `T`. (We say “claim” instead of “assert”, which is an unrelated concept.)
